### PR TITLE
Decrease logging level to DEBUG, make PSR-3 compatible

### DIFF
--- a/Logger/RedisLogger.php
+++ b/Logger/RedisLogger.php
@@ -11,7 +11,7 @@
 
 namespace Snc\RedisBundle\Logger;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * RedisLogger
@@ -48,9 +48,9 @@ class RedisLogger
         if (null !== $this->logger) {
             $this->commands[] = array('cmd' => $command, 'executionMS' => $duration, 'conn' => $connection, 'error' => $error);
             if ($error) {
-                $this->logger->err('Command "' . $command . '" failed (' . $error . ')');
+                $this->logger->error('Command "' . $command . '" failed (' . $error . ')');
             } else {
-                $this->logger->info('Executing command "' . $command . '"');
+                $this->logger->debug('Executing command "' . $command . '"');
             }
         }
     }


### PR DESCRIPTION
A lot of extra messages are generated by the logger at INFO, most of which aren't that useful in production environments. Decrease it to DEBUG and make it PSR-3 compatible.
