### PR TITLE
Only collect all command details in debug mode

### DIFF
--- a/Logger/RedisLogger.php
+++ b/Logger/RedisLogger.php
@@ -22,15 +22,18 @@ class RedisLogger
     protected $nbCommands = 0;
     protected $commands = array();
     protected $start;
+    protected $debug;
 
     /**
      * Constructor.
      *
      * @param LoggerInterface $logger A LoggerInterface instance
+     * @param bool $debug
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(LoggerInterface $logger = null, $debug = false)
     {
         $this->logger = $logger;
+        $this->debug  = $debug;
     }
 
     /**
@@ -46,7 +49,10 @@ class RedisLogger
         ++$this->nbCommands;
 
         if (null !== $this->logger) {
-            $this->commands[] = array('cmd' => $command, 'executionMS' => $duration, 'conn' => $connection, 'error' => $error);
+            if ($this->debug) {
+                $this->commands[] = array('cmd' => $command, 'executionMS' => $duration, 'conn' => $connection, 'error' => $error);
+            }
+
             if ($error) {
                 $this->logger->error('Command "' . $command . '" failed (' . $error . ')');
             } else {

--- a/Resources/config/redis.xml
+++ b/Resources/config/redis.xml
@@ -10,6 +10,7 @@
         <service id="snc_redis.logger" class="%snc_redis.logger.class%">
             <tag name="monolog.logger" channel="snc_redis" />
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="snc_redis.data_collector" class="%snc_redis.data_collector.class%" public="false">


### PR DESCRIPTION
Assumption: if SncRedisBundle is running in non-debug mode, there'll be no data collector, so no use for the collected command information anyway.

Previously, long-running production processes using SncRedisBundle would 'leak' memory by filling the commands array without ever reading it. (There's also no public interface that allows this array to be cleared, so the memory usage was effectively unbound).
